### PR TITLE
feat: add Task assignment and permission management (Issue #1101)

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -33,7 +33,9 @@ from .models import (
 )
 from .permissions import (
     CanEditProject,
+    CanEditTask,
     CanViewProjectDetails,
+    CanViewProjectTasks,
     IsProjectOwner,
     can_view_project_details,
 )
@@ -907,7 +909,7 @@ class TaskViewSet(viewsets.ModelViewSet):
     queryset = Task.objects.select_related(
         "project", "assigned_to", "milestone", "parent_task"
     ).prefetch_related("subtasks", "tags")
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, CanViewProjectTasks, CanEditTask]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["project_id", "status", "priority", "assigned_to", "milestone"]
     search_fields = ["title", "description"]


### PR DESCRIPTION
## Summary

Implement granular permission system for task management with role-based access control.

## Changes

**Permission Classes:**
- CanViewProjectTasks: View tasks in accessible projects
- CanEditTask: Edit with role-based rules:
  * Admins can edit all
  * Assignee can edit their task
  * Project owner can edit all
  * Project leads/managers can edit team tasks
- IsTaskAssigneeOrAdmin: Restrict to assignee or admin

**TaskViewSet Integration:**
- Apply permissions to all CRUD operations
- Object-level permission checks
- Respects TeamMember relationships

## Test Plan

- [ ] Test admin can edit any task
- [ ] Test assignee can edit their task
- [ ] Test non-assignee cannot edit
- [ ] Test project owner can edit
- [ ] Test project lead can edit team tasks
- [ ] Test view permissions

Closes #1101